### PR TITLE
Add listallpy skill

### DIFF
--- a/skills/.approvals.json
+++ b/skills/.approvals.json
@@ -29,6 +29,11 @@
     "seeded": true,
     "sha256": "b7a7e51b0869589b59a94a0a8fe37bf24580ca32ce5ede2bae28ba221fd68e2b"
   },
+  "listallpy": {
+    "recorded_at": "2026-08-05T17:33:41.659013+00:00",
+    "seeded": false,
+    "sha256": "b45e3a516c2971a2596ce724e5d5df69bf31a02e76dcf232bacee783fee85ee6"
+  },
   "refactor_extract_function": {
     "recorded_at": "2026-08-03T22:50:32.457745+00:00",
     "seeded": true,

--- a/skills/listallpy/SKILL.md
+++ b/skills/listallpy/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: listallpy
+description: list all python programs *.py in the current directory
+status: approved
+allowed_tools: [list_files]
+constraints: [workspace only, no network]
+---
+
+# listallpy
+
+Lists all Python files (*.py) in the current directory.
+
+## Usage
+
+```
+/skill listallpy
+```
+
+## Expected Output
+
+A list of all Python files in the current directory.
+
+## Constraints
+
+- List each constraint as a bullet point.
+- Works only within the workspace.
+- No network access allowed.

--- a/skills/listallpy/skill.py
+++ b/skills/listallpy/skill.py
@@ -1,0 +1,24 @@
+from py_mono.skill.base import Skill, SkillContext
+import logging
+import re
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+class ListallpySkill(Skill):
+
+    def name(self) -> str:
+        return "listallpy"
+
+    def description(self) -> str:
+        return "list all python programs *.py in the current directory"
+
+    def run(self, request: str, context: SkillContext) -> str:
+        try:
+            workspace = Path(context.workspace_root)
+            py_files = [f for f in workspace.rglob("*.py") if f.is_file()]
+            file_names = [f.name for f in py_files]
+            return "\n".join(file_names) or "No Python files found."
+        except Exception as e:
+            return f"[listallpy] Error: {e}"


### PR DESCRIPTION
## Summary
Adds the `listallpy` skill — generated live via `/skill generate_skill listallpy | list all python programs *.py in the current directory` against `qwen2.5-coder:7b-instruct-q5_K_M`, then reviewed and approved via `/approve listallpy` (recorded in `skills/.approvals.json`). This is a real, live end-to-end demonstration that the ISS-009 Ollama thinking-model fix works correctly with the new provider/model combination.

Lists `*.py` files under the workspace using `pathlib` only — no forbidden patterns, passes the existing validator.

Known cosmetic issue: its `SKILL.md` has a leaked template placeholder line under `## Constraints` (`- List each constraint as a bullet point.`) — this is the exact bug already tracked as ISS-011, not something new to fix here.

## Test plan
- [x] Approved via `/approve listallpy` (hash-ledger gate, ISS-003) — recorded in `skills/.approvals.json`
- [x] Ran via `/skill listallpy` in the live CLI — returned the expected file list