### PR TITLE
Refresh PROJECT_STATUS.md and CURRENT_FOCUS.md

### DIFF
--- a/docs/CURRENT_FOCUS.md
+++ b/docs/CURRENT_FOCUS.md
@@ -1,42 +1,44 @@
 # Current Focus
 
 ## Active branch
-`fix-ollama-thinking-response` — implementation complete, tested against real Ollama
-servers, awaiting review before push/PR.
+None — all recent work merged to `main`, working tree clean. Session moved from
+implementation into higher-level roadmap/product review (see below).
 
 ## What was just finished
-`ISS-009`: `OllamaProvider.generate()` sent no `think`/`num_predict`/`num_ctx`, so a
-thinking-capable Ollama model could exhaust its entire response budget on internal
-reasoning and return empty content (`done_reason: "length"`). Fixed with two defenses,
-both validated against real Ollama servers rather than assumed: `think: false` by default
-(`OLLAMA_ENABLE_THINKING`, genuinely eliminates reasoning cost for models with native
-Ollama thinking support, e.g. `qwen3.5:4b` — the model that produced the original bug
-report) plus `options.num_predict`/`num_ctx` (`OLLAMA_NUM_PREDICT`/`OLLAMA_NUM_CTX`) as a
-safety net for models that ignore the `think` field entirely (e.g. this repo's own local
-default, `lfm2.5-thinking:latest`). Also raised the previously-hardcoded 300s HTTP timeout
-to `OLLAMA_REQUEST_TIMEOUT` (default 600s), discovered necessary when the safety-net path
-alone exceeded 300s in real testing. Went through Spec Kit specify/plan/tasks first
-(`specs/005-fix-ollama-thinking-response/`) rather than being hot-patched from chat. See
-`docs/SESSION_LOG.md`'s 2026-08-05 entry for the full record, including a `capture-brainstorm-note`
-project skill added earlier the same session to capture the original bug report.
+- `ISS-009` (Ollama thinking-model empty response) — fixed and merged (PR #86). See
+  `docs/SESSION_LOG.md`'s 2026-08-05 entry for the full empirical record.
+- Live dogfood of that fix: generated and approved a real skill (`listallpy`) against a
+  newly-configured model (`qwen2.5-coder:7b-instruct-q5_K_M`) — confirmed working
+  end-to-end (PR #89).
+- That dogfood run surfaced two more findings, filed but not fixed: `ISS-010` (bare
+  `/provider` falls through to the LLM instead of showing usage, PR #87) and `ISS-011`
+  (three `generate_skill` output-quality gaps — asymmetric fence-stripping, a leaked
+  prompt template line, and a possible CPU-bound/unoffloaded inference signal, PR #88).
+- Compiled a consolidated high-level roadmap across `README.md` milestones,
+  `docs/ISSUES.md`, and `docs/NEXT_ACTIONS.md`, and started a product-level (not just
+  backlog-level) review of where to invest next.
 
 ## Why
-User hit the bug live while running `/skill generate_skill` against the local Ollama
-backend, then explicitly asked that the fix go through spec-driven development rather
-than being patched directly from the chat-based diagnosis that came with the bug report.
+User wanted a clear picture of "what are all the TODOs" across the project, then asked
+for a product-manager-level pass on top of that — not just the existing backlog, but
+what actually most improves the product next, informed by real friction hit this session
+(slow/unreliable local-model calls, generation-quality gaps, no CI, sparse test coverage).
 
 ## Not being worked on right now (explicitly out of scope)
 - `ISS-008` (full isolated-worker-with-RPC execution for skills/tools) — deferred,
   materially larger infrastructure item
-- `ISS-005` (pre-existing, unrelated test failures) — logged, not fixed
+- `ISS-005` (pre-existing, unrelated test failures) — logged, root cause not yet
+  investigated
 - `ISS-006` (pyyaml root dependency hygiene) — logged, not fixed
+- `ISS-010`, `ISS-011` — filed this session, explicitly deferred to Spec Kit, not fixed
 - Swapping `OLLAMA_REMOTE_MODEL`/`OLLAMA_LOCAL_MODEL` away from thinking-capable models —
-  discussed as a plausible complementary follow-up (a lighter, non-thinking, code-tuned
-  model would likely be faster and avoid this whole class of issue for structured
-  generation tasks) but explicitly a separate, deliberate decision, not bundled into this
-  fix (the fix must be correct regardless of which model is configured).
+  user has started manually testing `qwen2.5-coder:7b-instruct-q5_K_M`; no default change
+  made yet.
 
 ## Milestone note
-All three original critical audit findings (ISS-001/002/003) plus ISS-009 are now fixed.
-Remaining open items are minor/pre-existing (`ISS-005`, `ISS-006`) or explicitly deferred
-larger projects (`ISS-008`).
+All three original critical audit findings (ISS-001/002/003) plus ISS-009 are fixed and
+merged. Five issues remain open, none started: two small/well-scoped (`ISS-010`,
+`ISS-006`), one needing investigation before it's scoped (`ISS-005`), one large and
+deliberately deferred (`ISS-008`), one small-multi-part (`ISS-011`). Milestone 4
+(Documentation, full workflow testing, packaging) has never been started — M5 shipped
+ahead of it, and there is currently no CI/pre-commit enforcement anywhere in the repo.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -4,20 +4,24 @@ Snapshot of overall project state. Update at milestone boundaries, not every ses
 for moment-to-moment state use `CURRENT_FOCUS.md` and `SESSION_LOG.md` instead.
 
 ## Current milestone
-ms5-skills (skills layer, Spec Kit integration). Merged to `main`: `kb-template`,
-`ollama-dual-backend`, `fix-workspace-sandbox` (PRs #79-81), `fix-skill-tool-approval-gate`
-(ISS-003, PR #82), README/kb-template doc-drift cleanup (PR #83), the py-coding-agent
-lifecycle one-pager + cross-project reference redaction (PR #84), and the
-`capture-brainstorm-note` skill plus filing/speccing ISS-009 (PR #85). `fix-ollama-thinking-response`
-(ISS-009, the Ollama thinking-model empty-response fix) is implemented and tested — not yet
-pushed/merged. See `docs/SESSION_LOG.md` for full records.
+ms5-skills (skills layer, Spec Kit integration) is complete and in active use. Merged to
+`main`: `kb-template`, `ollama-dual-backend`, `fix-workspace-sandbox` (PRs #79-81),
+`fix-skill-tool-approval-gate` (ISS-003, PR #82), README/kb-template doc-drift cleanup
+(PR #83), the py-coding-agent lifecycle one-pager + cross-project reference redaction
+(PR #84), the `capture-brainstorm-note` skill plus filing/speccing ISS-009 (PR #85),
+`fix-ollama-thinking-response` (ISS-009, PR #86), filing ISS-010 (PR #87) and ISS-011
+(PR #88), and the `listallpy` skill — a live, real dogfood of the ISS-009 fix (PR #89).
+No branch currently active; working tree is clean off `main`. See `docs/SESSION_LOG.md`
+for full records.
 
 ## Known critical/open issues
 See `docs/ISSUES.md` for the live register. As of 2026-08-05: all three original critical
-audit findings (ISS-001/C-01, ISS-002/C-02, ISS-003/C-03) are fixed and merged. ISS-009
-(Ollama thinking-model empty response) is fixed, pending push/merge. Remaining open:
-`ISS-005`, `ISS-006` (minor, pre-existing), `ISS-008` (deferred isolated-worker execution
-project).
+audit findings (ISS-001/C-01, ISS-002/C-02, ISS-003/C-03) are fixed and merged, and ISS-009
+(Ollama thinking-model empty response) is fixed and merged. Remaining open, none started:
+`ISS-005` (pre-existing test failures, root cause not yet investigated), `ISS-006` (pyyaml
+dependency hygiene), `ISS-008` (deferred isolated-worker execution project), `ISS-010`
+(bare `/provider` falls through to the LLM), `ISS-011` (three `generate_skill`
+output-quality gaps found dogfooding against `qwen2.5-coder:7b-instruct-q5_K_M`).
 
 ## Architecture references
 - `docs/adr/` — standing architecture decisions (ADR-001 through ADR-019).


### PR DESCRIPTION
## Summary
Brings both docs current after PRs #86-89 (ISS-009 fix + merge, ISS-010/011 filing, the live `listallpy` skill dogfood) and today's roadmap/product review — both had gone stale (last touched before those merges).

## Test plan
- N/A — documentation-only change.