### PR TITLE
Fix ISS-006: declare pyyaml as a direct dependency

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/005-fix-ollama-thinking-response"
+  "feature_directory": "specs/007-add-pyyaml-direct-dependency"
 }

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -47,7 +47,6 @@ issue's own section below the index, not in the index table — keeps the table 
 | ID | Status | Milestone | Title | Branch |
 | --- | --- | --- | --- | --- |
 | ISS-005 | open | M6 | Pre-existing test failures unrelated to current branch work | — |
-| ISS-006 | open | M6 | `pyyaml` used transitively but not declared as a direct dependency | — |
 | ISS-008 | open | Gated (M8 prereq) | Full isolated-worker execution for skills/dynamic tools | — |
 | ISS-010 | open | M6 | Bare `/provider` silently falls through to the LLM | — |
 | ISS-011 | open | M6 | `generate_skill` output-quality gaps found dogfooding | — |
@@ -63,6 +62,7 @@ issue's own section below the index, not in the index table — keeps the table 
 | ISS-002 | done | M5 | `/workspace` sandbox escape via path-check bypass | fix-workspace-sandbox |
 | ISS-003 | done | M5 | Skills/dynamic tools execute arbitrary code before approval | fix-skill-tool-approval-gate |
 | ISS-004 | done | M5 | Add `kb-template/` portable knowledge-base scaffold | kb-template |
+| ISS-006 | done | M6 | `pyyaml` used transitively but not declared as a direct dependency | add-pyyaml-direct-dependency |
 | ISS-007 | done | M5 | Add dual Ollama backend selection with runtime model switching | ollama-dual-backend |
 | ISS-009 | done | M5 | `OllamaProvider` returns empty content for thinking-capable models | fix-ollama-thinking-response |
 
@@ -84,18 +84,6 @@ issue's own section below the index, not in the index table — keeps the table 
   Constitution Principle I
 - **Why it matters now:** blocks Milestone 6 CI from being green-required (see
   `docs/ROADMAP_PLAN.md`) — can't gate merges on a suite with known, undiagnosed red tests
-
-### ISS-006 — `pyyaml` used transitively but not declared as a direct dependency
-- **Milestone:** M6
-- **Source:** discovered 2026-08-03 during `kb-template` planning; unbundled 2026-08-03 per
-  external PR review
-- **What:** `py_mono/skill/validator.py`, `py_mono/skill/base.py`, and
-  `py_mono/playbook/playbookregistry.py` all `import yaml` directly, but it's only ever
-  resolved transitively (via `litellm`/`fastmcp`), never declared as a direct dependency
-- **History:** a fix was briefly bundled into the `kb-template` branch (commit `c3f8f80`) but
-  reverted, since `kb-template`'s own `pyproject.toml` already declares `pyyaml` independently
-  and doesn't need the root repo touched
-- **Scope:** separate, pre-existing hygiene gap, not a `kb-template` requirement
 
 ### ISS-008 — Full isolated-worker execution for skills/dynamic tools
 - **Milestone:** Gated / deferred — prerequisite for M8, not part of M6
@@ -230,6 +218,20 @@ issue's own section below the index, not in the index table — keeps the table 
 - **What:** reusable YAML front-matter + Obsidian-markdown scaffold with a standalone
   validator, extracted before further cross-project knowledge-base drift accumulates. See
   `specs/001-kb-template/`
+
+### ISS-006 — `pyyaml` used transitively but not declared as a direct dependency
+- **Milestone:** M6
+- **Source:** discovered 2026-08-03 during `kb-template` planning; unbundled 2026-08-03 per
+  external PR review
+- **Fix:** landed on branch `add-pyyaml-direct-dependency`. Added `pyyaml` (unpinned) to the
+  root `pyproject.toml`'s direct dependencies and regenerated `uv.lock`. Confirmed 4 direct
+  `import yaml` call sites first (`py_mono/skill/validator.py`, `py_mono/skill/base.py`,
+  `py_mono/playbook/playbookregistry.py`, `skills/generate_playbook/skill.py`)
+- **History:** a fix was briefly bundled into the `kb-template` branch (commit `c3f8f80`) but
+  reverted, since `kb-template`'s own `pyproject.toml` already declares `pyyaml` independently
+  and doesn't need the root repo touched
+- **Scope:** separate, pre-existing hygiene gap, not a `kb-template` requirement. See
+  `specs/007-add-pyyaml-direct-dependency/`
 
 ### ISS-007 — Add dual Ollama backend selection with runtime model switching
 - **Milestone:** M5

--- a/docs/ROADMAP_PLAN.md
+++ b/docs/ROADMAP_PLAN.md
@@ -63,7 +63,8 @@ modes every session.
 1. **`ISS-005`** — root-cause pre-existing test failures. Prerequisite to CI (`ISS-012`) being
    *green-required*, not just present — can't gate merges on a suite with known, undiagnosed
    red tests.
-2. **`ISS-006`** — declare `pyyaml` as a direct dependency. Small, mechanical.
+2. **`ISS-006`** — **done.** Declared `pyyaml` as a direct dependency. See [[ISSUES]] and
+   `specs/007-add-pyyaml-direct-dependency/`.
 3. **`ISS-010`** — bare `/provider` falls through to the LLM. Small, well-scoped — usage-message
    fix in `py_mono/agent/agent.py`.
 4. **`ISS-011`** — `generate_skill` fence-stripping + prompt-placeholder-leak fixes. Two code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "fastmcp==3.1.1",
     "mcp>=1.25.0",
     "cryptography",
-    "debugpy"
+    "debugpy",
+    "pyyaml"
 ]
 
 [build-system]

--- a/specs/007-add-pyyaml-direct-dependency/plan.md
+++ b/specs/007-add-pyyaml-direct-dependency/plan.md
@@ -1,0 +1,56 @@
+# Implementation Plan: Declare `pyyaml` as a direct dependency
+
+**Branch**: `add-pyyaml-direct-dependency` | **Date**: 2026-08-05 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/007-add-pyyaml-direct-dependency/spec.md`
+
+## Summary
+
+Added `pyyaml` to the root `pyproject.toml`'s `dependencies` list (unpinned, matching the
+convention already used for `requests`/`pandas`/`rich`) and regenerated `uv.lock`. Confirmed
+four direct `import yaml` call sites (`py_mono/skill/validator.py`, `py_mono/skill/base.py`,
+`py_mono/playbook/playbookregistry.py`, `skills/generate_playbook/skill.py`) before making the
+change; none required a version pin.
+
+## Technical Context
+
+**Language/Version**: Python (repo `requires-python = ">=3.10"`, unchanged)
+
+**Primary Dependencies**: `pyyaml` — was already present transitively via `litellm`/`fastmcp`;
+now declared directly
+
+**Storage**: N/A
+
+**Testing**: No behavior change; existing suite re-run to confirm no regression from the
+manifest/lockfile change alone
+
+**Target Platform**: Unchanged
+
+**Project Type**: Single project — manifest/lockfile change only
+
+**Constraints**: Root `pyproject.toml`/`uv.lock` only; `kb-template/`'s independent
+`pyproject.toml` (which already declares `pyyaml` on its own) explicitly not touched
+
+**Scale/Scope**: Minimal — one dependency line, one lockfile regeneration
+
+## Constitution Check
+
+- **Principle I (Minimal, Targeted Changes)**: PASS — single-line dependency addition, no
+  restructuring.
+- **Principle IV (Test Coverage for New Behavior)**: N/A — no new behavior; existing suite is
+  the regression check.
+- **Principle V (Incremental Change Philosophy)**: PASS — purely additive, no existing interface
+  changed.
+
+No violations.
+
+## Project Structure
+
+### Source Code (repository root)
+
+```text
+pyproject.toml   # + "pyyaml" under [project] dependencies
+uv.lock          # regenerated via `uv lock`
+```
+
+**Structure Decision**: No new structure — manifest/lockfile change only.

--- a/specs/007-add-pyyaml-direct-dependency/spec.md
+++ b/specs/007-add-pyyaml-direct-dependency/spec.md
@@ -1,0 +1,64 @@
+# Feature Specification: Declare `pyyaml` as a direct dependency
+
+**Feature Branch**: `add-pyyaml-direct-dependency`
+
+**Created**: 2026-08-05
+
+**Status**: Draft (documents completed, verified work)
+
+**Input**: User description: "Fix ISS-006 — `pyyaml` is imported directly by
+`py_mono/skill/validator.py`, `py_mono/skill/base.py`, `py_mono/playbook/playbookregistry.py`,
+and `skills/generate_playbook/skill.py`, but is only ever resolved transitively (via
+`litellm`/`fastmcp`), never declared as a direct dependency in the root `pyproject.toml`. See
+`docs/ISSUES.md` ISS-006."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Installing this project's declared dependencies is enough to run it (Priority: P1)
+
+A contributor installs this project from `pyproject.toml` alone. Every module the project
+imports directly should be guaranteed present by that install, not by an incidental transitive
+dependency of an unrelated package that could be upgraded or replaced later.
+
+**Why this priority**: This is a latent breakage risk — if `litellm` or `fastmcp` ever drop or
+change their `pyyaml` dependency, four files that `import yaml` directly would start failing
+with no warning from this project's own declared dependencies.
+
+**Independent Test**: Confirm `pyyaml` appears in `pyproject.toml`'s direct `dependencies` list
+and that `uv lock` resolves cleanly with it present.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh environment built only from this project's `pyproject.toml`, **When**
+   any module that does `import yaml` is imported, **Then** the import succeeds without relying
+   on another package's transitive dependency.
+
+### Edge Cases
+
+- Does this change affect `kb-template/`'s own dependency declarations? No — `kb-template/` has
+  its own separate `pyproject.toml` that already declares `pyyaml` independently; this issue is
+  scoped to the root project only (a prior attempt to bundle this fix into the `kb-template`
+  branch was reverted for exactly this reason — see `docs/ISSUES.md` ISS-006 history).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The root `pyproject.toml` MUST declare `pyyaml` as a direct dependency.
+- **FR-002**: `uv.lock` MUST be regenerated to reflect the updated direct-dependency graph.
+- **FR-003**: The change MUST NOT touch `kb-template/`'s independent dependency declarations.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `pyyaml` appears under `[project.dependencies]` in the root `pyproject.toml`.
+- **SC-002**: `uv lock` resolves without error after the change.
+- **SC-003**: The existing test suite's pass/fail outcome is unaffected by this change alone
+  (this is a manifest/lockfile change, not a behavior change).
+
+## Assumptions
+
+- `pyyaml`'s version is left unpinned (matching this project's existing convention for most
+  dependencies in `pyproject.toml`, e.g. `requests`, `pandas`, `rich`), since no specific version
+  constraint has ever been required by the four call sites that use it.

--- a/specs/007-add-pyyaml-direct-dependency/tasks.md
+++ b/specs/007-add-pyyaml-direct-dependency/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: Declare `pyyaml` as a direct dependency
+
+**Input**: Design documents from `/specs/007-add-pyyaml-direct-dependency/`
+
+All tasks below were already executed and verified.
+
+## Phase 1: Setup
+
+- [x] T001 Confirm all direct `import yaml` call sites via repo-wide search: found 4
+      (`py_mono/skill/validator.py`, `py_mono/skill/base.py`,
+      `py_mono/playbook/playbookregistry.py`, `skills/generate_playbook/skill.py`)
+
+## Phase 2: User Story 1 - Installing declared dependencies is enough to run this project (Priority: P1)
+
+- [x] T002 [US1] Add `"pyyaml"` to `pyproject.toml`'s `[project.dependencies]`, unpinned,
+      matching the convention for other unpinned dependencies in the same list
+- [x] T003 [US1] Run `uv lock` to regenerate `uv.lock` with `pyyaml` as a direct dependency
+- [x] T004 [US1] Run the full test suite to confirm no regression introduced by this change
+      alone (pre-existing, unrelated `ISS-005` failures are tracked and fixed separately in
+      PR #96, not part of this change's scope)
+
+## Dependencies & Execution Order
+
+Single linear sequence — no parallelism needed for a change this small.

--- a/uv.lock
+++ b/uv.lock
@@ -2041,6 +2041,7 @@ dependencies = [
     { name = "mcp" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
 ]
@@ -2058,6 +2059,7 @@ requires-dist = [
     { name = "litellm", specifier = "==1.82.6" },
     { name = "mcp", specifier = ">=1.25.0" },
     { name = "pandas" },
+    { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
 ]


### PR DESCRIPTION
## Summary
- Adds `pyyaml` (unpinned) to root `pyproject.toml`'s direct dependencies — 4 files `import yaml` directly but it was only ever resolved transitively via `litellm`/`fastmcp`.
- Regenerates `uv.lock`.
- Does not touch `kb-template/`'s independent `pyproject.toml`, which already declares `pyyaml` on its own (a prior attempt to bundle this into the `kb-template` branch was reverted for exactly this reason).
- Closes `ISS-006` in `docs/ISSUES.md`; SDD trail in `specs/007-add-pyyaml-direct-dependency/`.

## Test plan
- [x] `uv lock` resolves cleanly
- [x] `python -m compileall -q py_mono skills` — clean
- [x] Full suite re-run — no new failures introduced by this change (pre-existing `ISS-005` failures are tracked/fixed separately in #96, unrelated to this change)