### PR TITLE
Fix ISS-010: bare /provider falls through to the LLM

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/005-fix-ollama-thinking-response"
+  "feature_directory": "specs/008-fix-bare-provider-command"
 }

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -49,7 +49,6 @@ issue's own section below the index, not in the index table — keeps the table 
 | ISS-005 | open | M6 | Pre-existing test failures unrelated to current branch work | — |
 | ISS-006 | open | M6 | `pyyaml` used transitively but not declared as a direct dependency | — |
 | ISS-008 | open | Gated (M8 prereq) | Full isolated-worker execution for skills/dynamic tools | — |
-| ISS-010 | open | M6 | Bare `/provider` silently falls through to the LLM | — |
 | ISS-011 | open | M6 | `generate_skill` output-quality gaps found dogfooding | — |
 | ISS-012 | open | M6 | Add minimal CI (`pytest` + `compileall` on every PR) | — |
 | ISS-013 | open | M6 | Add lightweight per-run telemetry log | — |
@@ -65,6 +64,7 @@ issue's own section below the index, not in the index table — keeps the table 
 | ISS-004 | done | M5 | Add `kb-template/` portable knowledge-base scaffold | kb-template |
 | ISS-007 | done | M5 | Add dual Ollama backend selection with runtime model switching | ollama-dual-backend |
 | ISS-009 | done | M5 | `OllamaProvider` returns empty content for thinking-capable models | fix-ollama-thinking-response |
+| ISS-010 | done | M6 | Bare `/provider` silently falls through to the LLM | fix-bare-provider-command |
 
 ---
 
@@ -108,19 +108,6 @@ issue's own section below the index, not in the index table — keeps the table 
   gap via a hash-ledger gate, not content-level sandboxing
 - **Status:** tracked for future consideration, not started — also a prerequisite for
   Milestone 8 (`docs/ROADMAP_PLAN.md`), not just "eventually"
-
-### ISS-010 — Bare `/provider` silently falls through to the LLM
-- **Milestone:** M6
-- **Source:** 2026-08-05 session, user hit it live in the CLI
-- **What:** `py_mono/agent/agent.py`'s `_is_special_command`/`_handle_special_command` only
-  match `text.startswith("/provider ")` (trailing space + argument required) or the exact
-  string `/providers`. Bare `/provider` (no space, no argument) matches neither, so it's routed
-  to the LLM as a normal chat message instead of showing usage
-- **Reproduced live:** bare `/provider` produced an LLM reply ("What specific type of
-  \"provider\" were you asking about?"); `/provider ollama-auto qwen2.5-coder:7b-instruct-q5_K_M`
-  (the correct form) switched providers normally
-- **Fix:** deferred — to be routed through Spec Kit (specify → plan → tasks → implement) per
-  explicit instruction, not fixed inline
 
 ### ISS-011 — `generate_skill` output-quality gaps found dogfooding
 - **Milestone:** M6
@@ -262,3 +249,19 @@ issue's own section below the index, not in the index table — keeps the table 
   wrong way before testing against the actual model from the bug report corrected the design —
   see `specs/005-fix-ollama-thinking-response/research.md` for the full empirical trail. Raw
   capture: `kb-template/knowledge/raw/brainstorm-20260805-ollama-thinking-empty-response.md`
+
+### ISS-010 — Bare `/provider` silently falls through to the LLM
+- **Milestone:** M6
+- **Source:** 2026-08-05 session, user hit it live in the CLI
+- **Fix:** landed on branch `fix-bare-provider-command`. `py_mono/agent/agent.py`'s
+  `_is_special_command`/`_handle_special_command` only matched `text.startswith("/provider ")`
+  (trailing space + argument required) or the exact string `/providers`. Added the exact string
+  `"/provider"` to the recognized-commands tuple and a matching branch returning
+  `"Usage: /provider <provider> [model]"` (the same message already used for the
+  trailing-space case)
+- **Reproduced live before the fix:** bare `/provider` produced an LLM reply ("What specific
+  type of \"provider\" were you asking about?"); `/provider ollama-auto
+  qwen2.5-coder:7b-instruct-q5_K_M` (the correct form) switched providers normally
+- **Tests:** added `tests/test_special_commands.py` (5 tests: bare `/provider` recognized +
+  shows usage, trailing-space-only unaffected, `/providers` unaffected, valid-argument switching
+  unaffected). See `specs/008-fix-bare-provider-command/`

--- a/docs/ROADMAP_PLAN.md
+++ b/docs/ROADMAP_PLAN.md
@@ -64,8 +64,8 @@ modes every session.
    *green-required*, not just present — can't gate merges on a suite with known, undiagnosed
    red tests.
 2. **`ISS-006`** — declare `pyyaml` as a direct dependency. Small, mechanical.
-3. **`ISS-010`** — bare `/provider` falls through to the LLM. Small, well-scoped — usage-message
-   fix in `py_mono/agent/agent.py`.
+3. **`ISS-010`** — **done.** Bare `/provider` now shows usage instead of falling through to the
+   LLM. See [[ISSUES]] and `specs/008-fix-bare-provider-command/`.
 4. **`ISS-011`** — `generate_skill` fence-stripping + prompt-placeholder-leak fixes. Two code
    fixes (`py_mono/skill/validator.py`, `py_mono/skill/prompts.py`) plus one non-code
    investigation (`ollama ps`, possible CPU-bound/unoffloaded inference).

--- a/py_mono/agent/agent.py
+++ b/py_mono/agent/agent.py
@@ -93,7 +93,7 @@ class Agent:
 
     def _is_special_command(self, text: str) -> bool:
         text = text.strip()
-        if text in ("/clear", "/bye", "/providers", "/reload_tools"):
+        if text in ("/clear", "/bye", "/providers", "/reload_tools", "/provider"):
             return True
         if text.startswith("/provider "):
             return True
@@ -136,6 +136,9 @@ class Agent:
 
         if text == "/reload_tools":
             return self._reload_dynamic_tools()
+
+        if text == "/provider":
+            return "Usage: /provider <provider> [model]"
 
         if text.startswith("/provider "):
             parts = text.split(maxsplit=2)

--- a/specs/008-fix-bare-provider-command/plan.md
+++ b/specs/008-fix-bare-provider-command/plan.md
@@ -1,0 +1,58 @@
+# Implementation Plan: Fix bare `/provider` falling through to the LLM
+
+**Branch**: `fix-bare-provider-command` | **Date**: 2026-08-05 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/008-fix-bare-provider-command/spec.md`
+
+## Summary
+
+`Agent._is_special_command` matched `/provider ` (trailing space required) or the exact string
+`/providers`, so bare `/provider` (no space) matched neither and fell through to the LLM. Added
+the exact string `"/provider"` to the recognized-commands tuple in `_is_special_command`, and a
+matching `if text == "/provider":` branch in `_handle_special_command` returning the same usage
+message already used for the trailing-space case.
+
+## Technical Context
+
+**Language/Version**: Python (unchanged)
+
+**Primary Dependencies**: None new
+
+**Storage**: N/A
+
+**Testing**: `pytest`, new `tests/test_special_commands.py` constructing a real `Agent` +
+`SessionManager` (mirrors the existing pattern in `tests/test_skill_load_gating.py`'s
+`make_agent` helper) rather than mocking the dispatch methods
+
+**Target Platform**: Unchanged
+
+**Project Type**: Single project — one existing file changed
+
+**Constraints**: Fix confined to `py_mono/agent/agent.py`'s special-command dispatch; no other
+command's matching logic touched
+
+**Scale/Scope**: Minimal — two small additions to two existing methods, one new test file
+
+## Constitution Check
+
+- **Principle I (Minimal, Targeted Changes)**: PASS — two one-line additions to existing
+  methods, no restructuring of command dispatch.
+- **Principle IV (Test Coverage for New Behavior)**: PASS — `tests/test_special_commands.py`
+  added (5 tests: bare `/provider` recognized + shows usage, trailing-space-only unaffected,
+  `/providers` unaffected, valid-argument switching unaffected).
+- **Principle V (Incremental Change Philosophy)**: PASS — no existing command's behavior
+  changed, only a previously-unhandled input shape now handled.
+
+No violations.
+
+## Project Structure
+
+### Source Code (repository root)
+
+```text
+py_mono/agent/agent.py           # _is_special_command + _handle_special_command: bare "/provider"
+tests/test_special_commands.py   # new: 5 tests
+```
+
+**Structure Decision**: No new structure — one existing file changed, one new flat test file
+(matches `tests/test_skill_load_gating.py`'s existing flat placement convention).

--- a/specs/008-fix-bare-provider-command/spec.md
+++ b/specs/008-fix-bare-provider-command/spec.md
@@ -1,0 +1,68 @@
+# Feature Specification: Fix bare `/provider` falling through to the LLM
+
+**Feature Branch**: `fix-bare-provider-command`
+
+**Created**: 2026-08-05
+
+**Status**: Draft (documents completed, verified work)
+
+**Input**: User description: "Fix ISS-010 — typing bare `/provider` (no argument) in the CLI is
+not recognized as a special command and gets sent to the LLM as a normal chat message instead of
+showing usage, unlike `/provider <name>` or `/providers` which both work correctly. See
+`docs/ISSUES.md` ISS-010."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Typing `/provider` alone shows usage instead of confusing the LLM (Priority: P1)
+
+An operator forgets the required argument and types `/provider` alone in the CLI, expecting
+either the current provider info or a usage hint — the same kind of immediate, deterministic
+feedback every other malformed command in this CLI already gives.
+
+**Why this priority**: This is the concretely reported, reproducing bug — confirmed live: bare
+`/provider` produced an LLM reply asking what "provider" meant, instead of the CLI's own usage
+message.
+
+**Independent Test**: Type `/provider` alone and confirm a `Usage: /provider <provider> [model]`
+response is returned directly by the CLI, without an LLM call.
+
+**Acceptance Scenarios**:
+
+1. **Given** the CLI is running, **When** the user types `/provider` with no argument, **Then**
+   the CLI returns `Usage: /provider <provider> [model]` directly, with no LLM call made.
+2. **Given** the CLI is running, **When** the user types `/provider <name>` or
+   `/provider <name> <model>`, **Then** behavior is unchanged from before this fix (no
+   regression).
+3. **Given** the CLI is running, **When** the user types `/providers` (plural), **Then** it is
+   still handled by its own existing branch, unaffected by this fix.
+
+### Edge Cases
+
+- Does `/provider` with trailing whitespace only (`"/provider "`) still work? Yes — unaffected,
+  already handled by the existing `text.startswith("/provider ")` branch before this fix, which
+  already returned the same usage message for that case.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The CLI MUST recognize bare `/provider` (exact string, no argument) as a special
+  command, not a message to forward to the LLM.
+- **FR-002**: The CLI MUST respond to bare `/provider` with the same usage message already used
+  for `/provider ` (trailing space, no argument): `Usage: /provider <provider> [model]`.
+- **FR-003**: The fix MUST NOT change behavior for `/provider <name>`, `/provider <name> <model>`,
+  or `/providers`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Typing `/provider` alone returns the usage message directly, with zero LLM calls.
+- **SC-002**: Existing provider-switching and `/providers` behavior is unchanged, confirmed by
+  automated tests covering all four input shapes (bare, trailing-space-only, valid argument,
+  plural).
+
+## Assumptions
+
+- No other special command in this CLI has the same "requires a trailing space to be recognized"
+  gap — this fix is scoped to `/provider` only, since that's the one concretely reported.

--- a/specs/008-fix-bare-provider-command/tasks.md
+++ b/specs/008-fix-bare-provider-command/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Fix bare `/provider` falling through to the LLM
+
+**Input**: Design documents from `/specs/008-fix-bare-provider-command/`
+
+All tasks below were already executed and verified.
+
+## Phase 1: Setup
+
+- [x] T001 Reproduce the bug: confirm `agent._is_special_command("/provider")` returns `False`
+      before the fix, tracing through `_is_special_command`'s tuple check and
+      `text.startswith("/provider ")` check in `py_mono/agent/agent.py`
+
+## Phase 2: User Story 1 - Typing `/provider` alone shows usage (Priority: P1)
+
+- [x] T002 [US1] Add `"/provider"` to the exact-match tuple in `_is_special_command`
+      (`py_mono/agent/agent.py`)
+- [x] T003 [US1] Add `if text == "/provider": return "Usage: /provider <provider> [model]"` in
+      `_handle_special_command`, before the existing `text.startswith("/provider ")` branch
+- [x] T004 [US1] Add `tests/test_special_commands.py` with a `make_agent()` helper (real `Agent`
+      + `SessionManager`, mirroring `tests/test_skill_load_gating.py`'s pattern) and 5 tests:
+      bare `/provider` recognized as special + returns usage, trailing-space-only still returns
+      usage (regression guard), `/providers` (plural) unaffected, `/provider <valid-name>` still
+      switches successfully
+- [x] T005 [US1] Run `pytest tests/test_special_commands.py -v`: 5 passed
+- [x] T006 [US1] Run full suite + `compileall`: no new regressions (5 pre-existing, unrelated
+      `ISS-005` failures present, tracked/fixed separately in PR #96)
+
+## Dependencies & Execution Order
+
+Single linear sequence.

--- a/tests/test_special_commands.py
+++ b/tests/test_special_commands.py
@@ -1,0 +1,51 @@
+"""Tests for Agent._is_special_command / _handle_special_command dispatch
+(ISS-010: bare '/provider' with no argument silently fell through to the LLM
+instead of showing usage)."""
+
+from pathlib import Path
+
+from py_mono.agent.agent import Agent
+from py_mono.session.session_manager import SessionManager
+from py_mono.skill.base import SkillRegistry
+
+
+def make_agent(tmp_path: Path) -> Agent:
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    registry = SkillRegistry(skills_dir=skills_dir)
+    registry.load()
+    session_manager = SessionManager(default_provider="ollama")
+    return Agent(session_manager, tools=[], skill_registry=registry)
+
+
+def test_bare_provider_is_recognized_as_special_command(tmp_path):
+    agent = make_agent(tmp_path)
+    assert agent._is_special_command("/provider") is True
+
+
+def test_bare_provider_shows_usage(tmp_path):
+    agent = make_agent(tmp_path)
+    assert agent._handle_special_command("/provider") == "Usage: /provider <provider> [model]"
+
+
+def test_provider_with_trailing_space_only_still_shows_usage(tmp_path):
+    """Regression guard: '/provider ' (trailing space, no name) already showed
+    usage before this fix and must continue to."""
+    agent = make_agent(tmp_path)
+    assert agent._is_special_command("/provider ") is True
+    assert agent._handle_special_command("/provider ") == "Usage: /provider <provider> [model]"
+
+
+def test_providers_plural_is_unaffected(tmp_path):
+    """'/providers' must not be confused with bare '/provider'."""
+    agent = make_agent(tmp_path)
+    assert agent._is_special_command("/providers") is True
+    result = agent._handle_special_command("/providers")
+    assert result.startswith("Active provider:")
+
+
+def test_provider_with_valid_argument_still_switches(tmp_path):
+    agent = make_agent(tmp_path)
+    result = agent._handle_special_command("/provider ollama")
+    assert "Unknown provider" not in result
+    assert "Usage:" not in result


### PR DESCRIPTION
## Summary
- `Agent._is_special_command` only matched `/provider ` (trailing space) or the exact string `/providers` — bare `/provider` (no argument) matched neither and was silently routed to the LLM.
- Adds `"/provider"` to the recognized-commands tuple plus a matching branch in `_handle_special_command` returning `Usage: /provider <provider> [model]`.
- Adds `tests/test_special_commands.py` (5 tests covering all four input shapes).
- Closes `ISS-010` in `docs/ISSUES.md`; SDD trail in `specs/008-fix-bare-provider-command/`.

## Test plan
- [x] `pytest tests/test_special_commands.py -v` — 5 passed
- [x] Full suite — no new regressions (5 pre-existing `ISS-005` failures tracked/fixed separately in #96, unrelated to this change)
- [x] `python -m compileall -q py_mono skills` — clean