### PR TITLE
Fix ISS-011: generate_skill fence-stripping + prompt-placeholder leak

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/005-fix-ollama-thinking-response"
+  "feature_directory": "specs/009-generate-skill-quality-issues"
 }

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -50,7 +50,6 @@ issue's own section below the index, not in the index table — keeps the table 
 | ISS-006 | open | M6 | `pyyaml` used transitively but not declared as a direct dependency | — |
 | ISS-008 | open | Gated (M8 prereq) | Full isolated-worker execution for skills/dynamic tools | — |
 | ISS-010 | open | M6 | Bare `/provider` silently falls through to the LLM | — |
-| ISS-011 | open | M6 | `generate_skill` output-quality gaps found dogfooding | — |
 | ISS-012 | open | M6 | Add minimal CI (`pytest` + `compileall` on every PR) | — |
 | ISS-013 | open | M6 | Add lightweight per-run telemetry log | — |
 | ISS-014 | open | M6 | Add model/task fitness check | — |
@@ -65,6 +64,7 @@ issue's own section below the index, not in the index table — keeps the table 
 | ISS-004 | done | M5 | Add `kb-template/` portable knowledge-base scaffold | kb-template |
 | ISS-007 | done | M5 | Add dual Ollama backend selection with runtime model switching | ollama-dual-backend |
 | ISS-009 | done | M5 | `OllamaProvider` returns empty content for thinking-capable models | fix-ollama-thinking-response |
+| ISS-011 | done | M6 | `generate_skill` output-quality gaps found dogfooding | fix-generate-skill-quality-issues |
 
 ---
 
@@ -121,34 +121,6 @@ issue's own section below the index, not in the index table — keeps the table 
   (the correct form) switched providers normally
 - **Fix:** deferred — to be routed through Spec Kit (specify → plan → tasks → implement) per
   explicit instruction, not fixed inline
-
-### ISS-011 — `generate_skill` output-quality gaps found dogfooding
-- **Milestone:** M6
-- **Source:** 2026-08-05 session, user hit it live running
-  `/skill generate_skill listallpy | ...` after switching to a coding-tuned model; reviewed with
-  claude.ai, both findings re-verified against the actual code before filing
-- **Context:** three related findings from one *successful* (not failing) run — the underlying
-  ISS-009 fix worked; these are quality/robustness gaps in `generate_skill` itself
-- **What:**
-  1. **Fence-stripping isn't symmetric-only safe** — `_strip_markdown_fences()`
-     (`py_mono/skill/validator.py:233`) only strips a leading fence if the whole output starts
-     with one, and only strips a trailing fence if a leading one was already found. A
-     trailing-only fence leaves a stray `` ``` `` in the output; any preamble before the fence
-     (e.g. "Here's the code:\n```python...") isn't stripped at all and would fail `ast.parse()`
-     outright. Didn't manifest this run only because the model happened to fence symmetrically
-     with no preamble.
-  2. **Leaked template placeholder line** — `py_mono/skill/prompts.py:90` contains `- List each
-     constraint as a bullet point.`, phrased identically to a real constraint bullet, with
-     nothing marking it as instructional text to replace rather than content to keep. The model
-     echoed it back verbatim as a "constraint" in the generated `SKILL.md` (confirmed in the
-     transcript).
-  3. **Possible CPU-bound/unoffloaded inference** — both `generate_skill` LLM calls this run
-     showed prompt-processing throughput (~15 tok/s) in the same order of magnitude as
-     generation throughput (~6 tok/s); on GPU, prompt processing is normally an order of
-     magnitude faster than autoregressive generation, so near-parity suggests CPU-bound or
-     partial-GPU-offload inference — needs investigating via `ollama ps` or server-side GPU
-     offload logs, not a code fix in this repo.
-- **Fix:** deferred — to be routed through Spec Kit per explicit instruction, not fixed inline
 
 ### ISS-012 — Add minimal CI (`pytest` + `compileall` on every PR)
 - **Milestone:** M6
@@ -262,3 +234,30 @@ issue's own section below the index, not in the index table — keeps the table 
   wrong way before testing against the actual model from the bug report corrected the design —
   see `specs/005-fix-ollama-thinking-response/research.md` for the full empirical trail. Raw
   capture: `kb-template/knowledge/raw/brainstorm-20260805-ollama-thinking-empty-response.md`
+
+### ISS-011 — `generate_skill` output-quality gaps found dogfooding
+- **Milestone:** M6
+- **Source:** 2026-08-05 session, user hit it live running
+  `/skill generate_skill listallpy | ...` after switching to a coding-tuned model; reviewed with
+  claude.ai, both findings re-verified against the actual code before filing
+- **Context:** three related findings from one *successful* (not failing) run — the underlying
+  ISS-009 fix worked; these are quality/robustness gaps in `generate_skill` itself
+- **Fix:** landed on branch `fix-generate-skill-quality-issues`. Two code fixes plus one
+  non-code investigation:
+  1. **Fence-stripping** — `_strip_markdown_fences()` (`py_mono/skill/validator.py`) rewritten
+     to find a fenced code block via regex anywhere in the text, instead of requiring the
+     string to start with a fence. Fixes trailing-only fences and preamble-before-fence output.
+     Added `tests/test_skill_validator.py` (7 tests).
+  2. **Leaked template placeholder** — `py_mono/skill/prompts.py`'s
+     `build_skill_md_prompt()` fillable sections (paragraph description, expected output,
+     constraints) now marked with explicit `[INSTRUCTION — ...]` prefixes, plus a closing rule
+     telling the model never to copy an instruction marker into its output. Added
+     `tests/test_skill_prompts.py` (3 tests).
+  3. **CPU-bound/unoffloaded inference** — investigated directly against the reachable
+     `OLLAMA_REMOTE_URL` (`http://100.105.24.12:11434`): `/api/ps` after loading
+     `qwen2.5-coder:7b-instruct-q5_K_M` (the model from the original report) showed
+     `size_vram: 0` against a ~5.8 GB model — confirmed with a second model, also `size_vram: 0`.
+     The remote backend is not GPU-offloading inference at all, for any model tested, which
+     explains the originally-reported near-parity throughput. Not a code fix in this repo — see
+     `specs/009-generate-skill-quality-issues/research.md`. *Why* GPU offload isn't happening
+     would need direct access to that host's own system, out of this session's reach.

--- a/docs/ROADMAP_PLAN.md
+++ b/docs/ROADMAP_PLAN.md
@@ -66,9 +66,10 @@ modes every session.
 2. **`ISS-006`** — declare `pyyaml` as a direct dependency. Small, mechanical.
 3. **`ISS-010`** — bare `/provider` falls through to the LLM. Small, well-scoped — usage-message
    fix in `py_mono/agent/agent.py`.
-4. **`ISS-011`** — `generate_skill` fence-stripping + prompt-placeholder-leak fixes. Two code
-   fixes (`py_mono/skill/validator.py`, `py_mono/skill/prompts.py`) plus one non-code
-   investigation (`ollama ps`, possible CPU-bound/unoffloaded inference).
+4. **`ISS-011`** — **done.** Fence-stripping fixed (`py_mono/skill/validator.py`) and the leaked
+   prompt-placeholder line fixed (`py_mono/skill/prompts.py`). The non-code investigation
+   confirmed the remote Ollama backend isn't GPU-offloading at all (`size_vram: 0`), explaining
+   the near-parity throughput. See [[ISSUES]] and `specs/009-generate-skill-quality-issues/`.
 5. **`ISS-012`** — minimal CI (`pytest` + `python -m compileall` on every PR). Motivated
    directly by pre-existing untriaged test failures; every regression check before this was a
    human manually running `pytest`. Depends on `ISS-005` landing first.

--- a/py_mono/skill/prompts.py
+++ b/py_mono/skill/prompts.py
@@ -71,7 +71,8 @@ constraints: [brief human-readable constraints, e.g. "read-only, workspace only,
 
 # {skill_name}
 
-One paragraph explaining what this skill does.
+[INSTRUCTION — replace this bracketed line with one paragraph explaining what this skill does.
+Do not include this instruction, the brackets, or the word "INSTRUCTION" in your output.]
 
 ## Usage
 
@@ -83,16 +84,21 @@ One paragraph explaining what this skill does.
 
 ## Expected Output
 
-Brief description of what the user will see.
+[INSTRUCTION — replace this bracketed line with a brief description of what the user will see.
+Do not include this instruction, the brackets, or the word "INSTRUCTION" in your output.]
 
 ## Constraints
 
-- List each constraint as a bullet point.
+[INSTRUCTION — replace this bracketed line with 1-3 real constraints, each its own bullet point,
+e.g. "- Read-only, no writes to disk." Do not include this instruction, the brackets, or the
+word "INSTRUCTION" in your output.]
 
 Rules:
 - status MUST be "proposed" — never "approved"
 - allowed_tools must only contain tools from the available tools list above
 - Keep it concise and human-readable
+- Every [INSTRUCTION — ...] bracketed line above is a placeholder for YOU to replace with real
+  content — never copy an [INSTRUCTION — ...] line itself into the output
 """
 
 

--- a/py_mono/skill/validator.py
+++ b/py_mono/skill/validator.py
@@ -230,15 +230,30 @@ def validate_skill_py(code: str, skill_name: str) -> SkillPyValidationResult:
 # Helpers
 # ---------------------------------------------------------------------------
 
+_FENCE_BLOCK_RE = re.compile(r"```[ \t]*[A-Za-z0-9_+-]*[ \t]*\r?\n(.*?)```", re.DOTALL)
+
+
 def _strip_markdown_fences(code: str) -> str:
+    """Strip a Markdown code fence from LLM output before parsing/saving it.
+
+    Handles three shapes the previous, leading-fence-only version missed
+    (ISS-011): a fence with preamble text before it (e.g. "Here's the
+    code:\\n```python\\n..."), a trailing-only fence with no leading fence,
+    and any lone leading/trailing fence left over once a full block is
+    stripped.
+    """
     code = code.strip()
-    if code.startswith("```"):
-        lines = code.splitlines()
+
+    match = _FENCE_BLOCK_RE.search(code)
+    if match:
+        return match.group(1).strip("\n")
+
+    lines = code.splitlines()
+    if lines and lines[0].strip().startswith("```"):
         lines = lines[1:]
-        if lines and lines[-1].strip() == "```":
-            lines = lines[:-1]
-        code = "\n".join(lines)
-    return code
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
 
 def _find_skill_subclasses(tree: ast.Module) -> List[ast.ClassDef]:
     result = []

--- a/specs/009-generate-skill-quality-issues/plan.md
+++ b/specs/009-generate-skill-quality-issues/plan.md
@@ -1,0 +1,69 @@
+# Implementation Plan: `generate_skill` output-quality fixes
+
+**Branch**: `fix-generate-skill-quality-issues` | **Date**: 2026-08-05 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/009-generate-skill-quality-issues/spec.md`
+
+## Summary
+
+Two code fixes plus one non-code investigation, independent of each other. (1)
+`_strip_markdown_fences` (`py_mono/skill/validator.py`) rewritten to find a fenced block via
+regex anywhere in the text rather than requiring the string to start with one, fixing
+trailing-only and preamble-prefixed fences. (2) `build_skill_md_prompt()`
+(`py_mono/skill/prompts.py`) template sections marked with explicit `[INSTRUCTION — ...]`
+prefixes plus a reinforcing closing rule, so the model can't mistake instructional prose for
+literal content to echo back. (3) Confirmed via direct API queries against the remote Ollama
+backend (`size_vram: 0` for two different loaded models) that it is not GPU-offloading
+inference at all — documented in `research.md`, no code change applies.
+
+## Technical Context
+
+**Language/Version**: Python (unchanged)
+
+**Primary Dependencies**: None new — `re` already imported in `validator.py`
+
+**Storage**: N/A
+
+**Testing**: `pytest`; new `tests/test_skill_validator.py` (7 tests) and
+`tests/test_skill_prompts.py` (3 tests)
+
+**Target Platform**: Unchanged for the code fixes; Finding 3's investigation used direct HTTP
+access to the remote Ollama host's API (`http://100.105.24.12:11434`, reachable from this
+session per `.env.example`'s documented `OLLAMA_REMOTE_URL`)
+
+**Project Type**: Single project — two existing files changed
+
+**Constraints**: Fixes confined to `py_mono/skill/validator.py`'s `_strip_markdown_fences` and
+`py_mono/skill/prompts.py`'s `build_skill_md_prompt`; no other validator/prompt logic touched;
+Finding 3 produces no code change by design (external server configuration, not this repo's
+logic)
+
+**Scale/Scope**: Small — one function rewritten, one prompt template's wording adjusted, two new
+test files (10 tests total)
+
+## Constitution Check
+
+- **Principle I (Minimal, Targeted Changes)**: PASS — `_strip_markdown_fences` keeps its
+  existing signature and call sites unchanged; the prompt fix is a wording change to existing
+  template sections, not new sections or new parameters.
+- **Principle IV (Test Coverage for New Behavior)**: PASS — 10 new tests across two new test
+  files covering both fixes' previously-uncovered behavior.
+- **Principle V (Incremental Change Philosophy)**: PASS — the already-working symmetric-fence
+  case is preserved (regression test included); the prompt's existing guidance prose is kept,
+  only marked more explicitly rather than replaced.
+
+No violations.
+
+## Project Structure
+
+### Source Code (repository root)
+
+```text
+py_mono/skill/validator.py        # _strip_markdown_fences rewritten (regex-based)
+py_mono/skill/prompts.py          # build_skill_md_prompt(): [INSTRUCTION — ...] markers added
+tests/test_skill_validator.py     # new: 7 tests
+tests/test_skill_prompts.py       # new: 3 tests
+```
+
+**Structure Decision**: No new structure — two existing files changed, two new flat test files
+(matches this repo's existing flat `tests/` convention).

--- a/specs/009-generate-skill-quality-issues/research.md
+++ b/specs/009-generate-skill-quality-issues/research.md
@@ -1,0 +1,76 @@
+# Research: `generate_skill` output-quality fixes
+
+## Finding 1 — Fence stripping fails on asymmetric/preamble-prefixed output
+
+**Decision**: Replace the leading-fence-only logic with a regex search for a complete fenced
+block anywhere in the text (`` ```[lang]\n...``` ``), falling back to stripping a lone
+leading/trailing fence line if no complete pair is found.
+
+**Rationale**: The previous implementation (`code.startswith("```")` gate, then strip first and
+last line) structurally could not handle a trailing-only fence or preamble text before the
+fence, because it never looked for a fence unless the string started with one. Verified via new
+tests (`tests/test_skill_validator.py`) covering all four shapes.
+
+**Alternatives considered**: Prompting the model more strictly to never include fences at all
+(the prompt already says "Do NOT include markdown code fences"). Rejected as the sole fix —
+defense-in-depth against non-compliant model output is the point of `_strip_markdown_fences`
+existing at all; a prompt instruction alone doesn't guarantee compliance, which is exactly what
+this bug demonstrated.
+
+## Finding 2 — Leaked template placeholder line
+
+**Decision**: Mark every fillable section in `build_skill_md_prompt()`'s template
+(`# {skill_name}` paragraph, `## Expected Output`, `## Constraints`) with an explicit
+`[INSTRUCTION — ...]` prefix, and add a closing rule telling the model never to copy an
+instruction marker into its output.
+
+**Rationale**: `- List each constraint as a bullet point.` was phrased identically to a real
+constraint bullet — nothing in its wording distinguished "text describing what to write" from
+"text to write." Confirmed reproduced: a real generation run against
+`qwen2.5-coder:7b-instruct-q5_K_M` echoed it back verbatim into the generated `SKILL.md`. The
+same structural risk existed for two sibling lines in the same template (the one-paragraph
+description and the expected-output description) — fixed consistently rather than only the one
+line that happened to get caught.
+
+**Alternatives considered**: Removing the instructional prose entirely and leaving blank
+sections for the model to fill freeform. Rejected — the existing prose ("one paragraph
+explaining...", "brief description of...") gives the model useful guidance on length/tone that a
+bare blank section would lose; marking it as an instruction preserves that guidance while making
+it unambiguous that the text itself shouldn't be copied.
+
+## Finding 3 — CPU-bound/unoffloaded inference on the remote backend
+
+**Decision**: Query the remote Ollama backend directly (`OLLAMA_REMOTE_URL` from
+`.env.example`, `http://100.105.24.12:11434`, reachable from this session) rather than guessing.
+
+**Evidence gathered**:
+
+1. `curl http://100.105.24.12:11434/api/generate` with `qwen2.5-coder:7b-instruct-q5_K_M` (the
+   model from the original bug report) and a moderate prompt, followed immediately by
+   `curl http://100.105.24.12:11434/api/ps`:
+   ```json
+   {"name": "qwen2.5-coder:7b-instruct-q5_K_M", "size": 5824325876, "size_vram": 0, ...}
+   ```
+   `size_vram: 0` against a `size` of ~5.8 GB — **zero bytes of this model are offloaded to
+   GPU memory**. It is running entirely on CPU.
+2. Repeated with a second, smaller model already present on the same host (`qwen3.5:4b`,
+   ~3.2 GB): also `size_vram: 0`. Not model-specific — the host is not GPU-offloading any
+   currently-loaded model.
+
+**Conclusion**: This directly explains the originally-reported near-parity between
+prompt-processing and generation throughput — both are CPU-bound, so GPU's normal advantage
+(much faster parallel prompt processing than sequential generation) isn't present. This is a
+genuine finding, not a code bug in this repository: the "remote GPU backend"
+(`OLLAMA_REMOTE_URL`, per ADR/ISS-007's dual-backend design) is not currently GPU-accelerating
+inference for any model tested.
+
+**Not determined** (would require direct access to that host's own system, not just its Ollama
+API port): *why* GPU offload isn't happening — could be no GPU actually present on that host
+despite its "remote GPU desktop" designation, a driver/CUDA issue, or Ollama configured with GPU
+layers disabled. Flagged as a follow-up for whoever has direct access to that machine.
+
+**Alternatives considered**: Guessing based on the original report's tok/s numbers alone.
+Rejected — a repeat of this session's own test produced a different tok/s ratio (364 vs 6.6
+tok/s, not the originally reported ~15 vs ~6) for a shorter prompt, showing tok/s ratios alone
+are prompt-dependent and not reliable evidence on their own; `size_vram` is a direct,
+unambiguous measurement instead of an inference from timing.

--- a/specs/009-generate-skill-quality-issues/spec.md
+++ b/specs/009-generate-skill-quality-issues/spec.md
@@ -1,0 +1,126 @@
+# Feature Specification: `generate_skill` output-quality fixes
+
+**Feature Branch**: `fix-generate-skill-quality-issues`
+
+**Created**: 2026-08-05
+
+**Status**: Draft (documents completed, verified work)
+
+**Input**: User description: "Fix ISS-011 — three findings from dogfooding `generate_skill`
+against a coding-tuned model: (1) markdown-fence stripping isn't safe for asymmetric or
+preamble-prefixed fences, (2) a leaked, unmarked template placeholder line in the SKILL.md
+prompt got echoed verbatim into generated output, (3) possible CPU-bound/unoffloaded inference
+on the remote GPU backend. See `docs/ISSUES.md` ISS-011."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Fenced LLM output parses regardless of how the model fences it (Priority: P1)
+
+An operator generates a skill with a model that doesn't fence its output symmetrically (only a
+trailing fence, or explanatory preamble before the fence). The generated code should still parse
+and validate correctly instead of failing with a syntax error caused by a leftover fence marker.
+
+**Why this priority**: This is a latent correctness bug — the previous implementation only
+handled the one fencing shape (leading-fence, optional matching trailing fence) it happened to
+be tested against; two other realistic shapes silently broke `ast.parse()`.
+
+**Independent Test**: Feed fence-stripping a trailing-only fence and a preamble-plus-fence input
+and confirm both return clean, parseable code.
+
+**Acceptance Scenarios**:
+
+1. **Given** LLM output with a leading and matching trailing fence, **When** stripped, **Then**
+   the result is unchanged from before this fix (no regression).
+2. **Given** LLM output with only a trailing fence and no leading fence, **When** stripped,
+   **Then** the trailing fence is removed and the remaining code is returned.
+3. **Given** LLM output with explanatory text before a fenced block, **When** stripped, **Then**
+   only the fenced block's content is returned.
+4. **Given** LLM output with no fence at all, **When** stripped, **Then** it is returned
+   unchanged.
+
+---
+
+### User Story 2 - Generated `SKILL.md` never contains leaked template instructions (Priority: P1)
+
+An operator generates a new skill's `SKILL.md`. The generated file should contain only real
+content the operator would recognize as describing their skill — never a leftover instruction
+line from the prompt template itself.
+
+**Why this priority**: Confirmed reproduced in a real generation run — a real prompt-template
+line intended as an instruction to the model ("list each constraint as a bullet point") was
+phrased identically to genuine content and got echoed verbatim into the generated `SKILL.md`.
+
+**Independent Test**: Generate `build_skill_md_prompt()`'s output and confirm every fillable
+section is unambiguously marked as an instruction to replace, not phrased as literal content.
+
+**Acceptance Scenarios**:
+
+1. **Given** the SKILL.md prompt template, **When** inspected, **Then** every fillable section
+   (paragraph description, expected output, constraints) is marked with an explicit
+   `[INSTRUCTION — ...]` marker distinguishing it from literal content.
+2. **Given** the prompt's closing rules, **When** inspected, **Then** they explicitly tell the
+   model never to copy an instruction marker into its output.
+
+---
+
+### User Story 3 - Understand whether the remote backend is actually GPU-accelerating inference (Priority: P2)
+
+An operator wants to know whether the previously-observed near-parity prompt/generation
+throughput on the "remote GPU" Ollama backend indicates a real infrastructure problem, so future
+sessions don't have to re-derive this.
+
+**Why this priority**: Lower than the two code fixes (P1) since this investigation, by its own
+nature, cannot be resolved with a code change in this repository — it's about the state of an
+external Ollama server this repo talks to, not this repo's own logic.
+
+**Independent Test**: Query the remote Ollama backend's `/api/ps` endpoint after loading a model
+and inspect the `size_vram` field.
+
+**Acceptance Scenarios**:
+
+1. **Given** the remote Ollama backend has a model loaded, **When** `/api/ps` is queried,
+   **Then** the `size_vram` field reveals whether any of the model is actually offloaded to GPU
+   memory.
+
+### Edge Cases
+
+- Does the fence-stripping fix change behavior for the common, already-working case (symmetric
+  fence)? No — covered by an explicit regression test (FR-004).
+- Does marking prompt sections as `[INSTRUCTION — ...]` risk a model echoing the marker itself
+  instead of real content? Addressed directly by an explicit closing rule telling the model not
+  to copy instruction markers, matching this prompt's existing pattern of an explicit "Rules"
+  section reinforcing format requirements.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `_strip_markdown_fences` MUST correctly strip a fenced code block regardless of
+  whether the fence is symmetric (leading + trailing), leading-only, trailing-only, or preceded
+  by preamble text.
+- **FR-002**: `_strip_markdown_fences` MUST return input unchanged when no fence is present.
+- **FR-003**: `build_skill_md_prompt()`'s fillable template sections MUST be unambiguously
+  marked as instructions, not phrased as literal example content.
+- **FR-004**: Automated regression tests MUST cover the previously-broken fence shapes
+  (trailing-only, preamble-prefixed) in addition to the already-working shapes.
+- **FR-005**: The CPU-bound/unoffloaded-inference investigation MUST be documented with concrete
+  evidence (not a code change), since it concerns an external server's configuration, not this
+  repository's logic.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All four fence shapes (symmetric, leading-only, trailing-only, preamble-prefixed)
+  produce parseable output, verified by automated tests.
+- **SC-002**: The old ambiguous constraint-instruction line no longer appears anywhere in the
+  SKILL.md prompt template, verified by an automated test.
+- **SC-003**: A concrete, reproducible finding (not a guess) is recorded for the remote-backend
+  GPU-offload question, usable by a future session without re-deriving it.
+
+## Assumptions
+
+- The CPU-bound/unoffloaded-inference investigation is scoped to what's observable from this
+  repo's network access to the remote Ollama host's API (`/api/ps`, `/api/generate` timing
+  fields) — diagnosing *why* GPU offload isn't happening (driver issue, host configuration, no
+  GPU present) would require direct access to that host's own system, out of scope here.

--- a/specs/009-generate-skill-quality-issues/tasks.md
+++ b/specs/009-generate-skill-quality-issues/tasks.md
@@ -1,0 +1,60 @@
+# Tasks: `generate_skill` output-quality fixes
+
+**Input**: Design documents from `/specs/009-generate-skill-quality-issues/`
+
+All tasks below were already executed and verified.
+
+## Phase 1: Setup
+
+- [x] T001 Re-confirm both code-level findings against current `main`: read
+      `py_mono/skill/validator.py`'s `_strip_markdown_fences` and
+      `py_mono/skill/prompts.py`'s `build_skill_md_prompt` to verify both bugs as filed are
+      still present
+
+## Phase 2: User Story 1 - Fenced output parses regardless of fencing shape (Priority: P1)
+
+- [x] T002 [US1] Rewrite `_strip_markdown_fences` in `py_mono/skill/validator.py`: regex search
+      (`` ```[lang]\n(.*?)``` ``, `re.DOTALL`) for a complete fenced block anywhere in the text;
+      fall back to stripping a lone leading/trailing fence line if no complete pair is found
+- [x] T003 [US1] [P] Add `tests/test_skill_validator.py` (7 tests): symmetric fence (regression),
+      no-language-tag fence, leading-only fence, trailing-only fence (previously broken),
+      preamble-before-fence (previously broken), no fence at all, multiline code preserved
+- [x] T004 [US1] Run `pytest tests/test_skill_validator.py -v`: 7 passed
+
+## Phase 3: User Story 2 - No leaked template instructions in generated SKILL.md (Priority: P1)
+
+- [x] T005 [US2] Mark `build_skill_md_prompt()`'s three fillable sections (paragraph
+      description, expected output, constraints) with explicit `[INSTRUCTION — ...]` prefixes in
+      `py_mono/skill/prompts.py`
+- [x] T006 [US2] Add a closing rule reinforcing that `[INSTRUCTION — ...]` lines must never be
+      copied into the model's output
+- [x] T007 [US2] [P] Add `tests/test_skill_prompts.py` (3 tests): old ambiguous line is gone,
+      exactly 5 occurrences of the instruction marker (3 placeholders + 2 mentions in the
+      closing rule), rule text present
+- [x] T008 [US2] Run `pytest tests/test_skill_prompts.py -v`: 3 passed
+
+## Phase 4: User Story 3 - Document the remote-backend GPU-offload question (Priority: P2)
+
+- [x] T009 [US3] Confirm `OLLAMA_REMOTE_URL` (`http://100.105.24.12:11434`, from
+      `.env.example`) is reachable from this session via `curl`
+- [x] T010 [US3] Query `/api/generate` for `qwen2.5-coder:7b-instruct-q5_K_M` (the model from
+      the original bug report) with a moderate-complexity prompt, then `/api/ps` immediately
+      after: `size_vram: 0` against a `size` of ~5.8 GB
+- [x] T011 [US3] [P] Repeat against a second, smaller model already loaded on the same host
+      (`qwen3.5:4b`) to confirm the finding is host-wide, not model-specific: also
+      `size_vram: 0`
+- [x] T012 [US3] Record findings in `research.md`: the remote backend is not GPU-offloading any
+      currently-tested model, explaining the originally-reported near-parity throughput; root
+      cause of *why* GPU offload isn't happening flagged as needing direct host access, out of
+      this session's reach
+
+## Phase 5: Polish & Cross-Cutting
+
+- [x] T013 Run full suite + `compileall`: no new regressions (5 pre-existing, unrelated
+      `ISS-005` failures present, tracked/fixed separately in PR #96); 10 new tests included in
+      the pass count
+
+## Dependencies & Execution Order
+
+User Stories 1, 2, and 3 are fully independent (different files, no shared state) and were
+executed in parallel in practice.

--- a/tests/test_skill_prompts.py
+++ b/tests/test_skill_prompts.py
@@ -1,0 +1,34 @@
+"""Tests for py_mono/skill/prompts.py's SKILL.md prompt template (ISS-011).
+
+build_skill_md_prompt() previously included a literal, unmarked instruction
+line ("- List each constraint as a bullet point.") phrased identically to a
+real constraint bullet, with nothing distinguishing it as text for the model
+to replace rather than content to keep verbatim — confirmed reproduced: a
+real generation run echoed it back into the generated SKILL.md unchanged."""
+
+from py_mono.skill.prompts import build_skill_md_prompt
+
+
+def _build():
+    return build_skill_md_prompt(
+        skill_name="demo_skill",
+        description="a demo skill",
+        available_tools={"list_files": "List files"},
+    )
+
+
+def test_old_ambiguous_constraint_line_is_gone():
+    prompt = _build()
+    assert "- List each constraint as a bullet point." not in prompt
+
+
+def test_fillable_sections_are_marked_as_instructions():
+    prompt = _build()
+    # 3 real placeholders (paragraph, expected-output, constraints) plus 2
+    # more mentions of the pattern in the closing Rules reminder.
+    assert prompt.count("[INSTRUCTION —") == 5
+
+
+def test_rules_tell_the_model_not_to_copy_instruction_lines():
+    prompt = _build()
+    assert "never copy an [INSTRUCTION" in prompt

--- a/tests/test_skill_validator.py
+++ b/tests/test_skill_validator.py
@@ -1,0 +1,47 @@
+"""Tests for py_mono/skill/validator.py's Markdown-fence stripping (ISS-011).
+
+The previous implementation only stripped a leading fence when the whole
+output started with one, and only stripped a trailing fence if a leading one
+had already been found — so a trailing-only fence, or any preamble text
+before the leading fence, was left in place and would fail ast.parse()."""
+
+from py_mono.skill.validator import _strip_markdown_fences
+
+
+def test_symmetric_fence_is_stripped():
+    code = "```python\nx = 1\n```"
+    assert _strip_markdown_fences(code) == "x = 1"
+
+
+def test_symmetric_fence_without_language_tag_is_stripped():
+    code = "```\nx = 1\n```"
+    assert _strip_markdown_fences(code) == "x = 1"
+
+
+def test_leading_fence_with_no_trailing_fence_is_stripped():
+    code = "```python\nx = 1"
+    assert _strip_markdown_fences(code) == "x = 1"
+
+
+def test_trailing_only_fence_is_stripped():
+    """A response with no leading fence but a stray trailing fence — the
+    exact shape the previous implementation left unstripped."""
+    code = "x = 1\n```"
+    assert _strip_markdown_fences(code) == "x = 1"
+
+
+def test_preamble_before_fence_is_stripped():
+    """A response with explanatory text before the fence — previously not
+    stripped at all, since the code didn't start with the fence."""
+    code = "Here's the code:\n```python\nx = 1\n```"
+    assert _strip_markdown_fences(code) == "x = 1"
+
+
+def test_no_fence_at_all_is_returned_unchanged():
+    code = "x = 1"
+    assert _strip_markdown_fences(code) == "x = 1"
+
+
+def test_multiline_fenced_code_preserves_internal_structure():
+    code = "```python\ndef f():\n    return 1\n```"
+    assert _strip_markdown_fences(code) == "def f():\n    return 1"


### PR DESCRIPTION
## Summary
- Rewrites `_strip_markdown_fences` (`py_mono/skill/validator.py`) to find a fenced block via regex anywhere in the text, fixing trailing-only and preamble-prefixed fences that previously left a stray fence marker and broke `ast.parse()`.
- Marks `build_skill_md_prompt`'s (`py_mono/skill/prompts.py`) fillable sections with explicit `[INSTRUCTION — ...]` markers, fixing the confirmed-reproduced leaked-placeholder bug (a template instruction line got echoed verbatim into a real generated `SKILL.md`).
- Investigates the reported CPU-bound/unoffloaded-inference signature directly against the reachable remote Ollama backend — `/api/ps` shows `size_vram: 0` for two different loaded models, confirming the backend isn't GPU-offloading at all. Documented, not a code fix.
- Closes `ISS-011` in `docs/ISSUES.md`; SDD trail in `specs/009-generate-skill-quality-issues/` (includes `research.md` with the GPU-offload investigation).

## Test plan
- [x] `pytest tests/test_skill_validator.py tests/test_skill_prompts.py -v` — 10 passed
- [x] Full suite — no new regressions (5 pre-existing `ISS-005` failures tracked/fixed separately in #96, unrelated to this change)
- [x] `python -m compileall -q py_mono skills` — clean