### PR TITLE
Fix ISS-014: add model/task fitness check

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/011-add-skill-run-telemetry"
+  "feature_directory": "specs/012-add-model-task-fitness-check"
 }

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -52,7 +52,6 @@ issue's own section below the index, not in the index table — keeps the table 
 | ISS-010 | open | M6 | Bare `/provider` silently falls through to the LLM | — |
 | ISS-011 | open | M6 | `generate_skill` output-quality gaps found dogfooding | — |
 | ISS-012 | open | M6 | Add minimal CI (`pytest` + `compileall` on every PR) | — |
-| ISS-014 | open | M6 | Add model/task fitness check | — |
 
 ## Closed Index
 
@@ -65,6 +64,7 @@ issue's own section below the index, not in the index table — keeps the table 
 | ISS-007 | done | M5 | Add dual Ollama backend selection with runtime model switching | ollama-dual-backend |
 | ISS-009 | done | M5 | `OllamaProvider` returns empty content for thinking-capable models | fix-ollama-thinking-response |
 | ISS-013 | done | M6 | Add lightweight per-run telemetry log | add-skill-run-telemetry |
+| ISS-014 | done | M6 | Add model/task fitness check | add-model-task-fitness-check |
 
 ---
 
@@ -160,15 +160,6 @@ issue's own section below the index, not in the index table — keeps the table 
   suite has known, undiagnosed red tests. `ISS-005` should land first.
 - **Fix:** not started — to be routed through Spec Kit
 
-### ISS-014 — Add model/task fitness check
-- **Milestone:** M6
-- **Source:** filed 2026-08-05 from `docs/ROADMAP_PLAN.md` M6 scope
-- **What:** warn before a heavy generation call if the configured model looks like a poor fit
-  for structured output. Directly productizes the `ISS-009`/`ISS-011` lesson (thinking models
-  reasoning verbosely/unreliably on template-filling tasks).
-- **Depends on:** `ISS-013` — needs the per-run telemetry log to have data to check fitness
-  against. Sequence last within M6.
-- **Fix:** not started — to be routed through Spec Kit
 
 ---
 
@@ -267,3 +258,17 @@ issue's own section below the index, not in the index table — keeps the table 
   `dynamic_tools/` pattern; operational data, not source). Added `tests/test_skill_telemetry.py`
   (5 tests) and 3 new tests in `tests/test_skill_approval.py`. See
   `specs/011-add-skill-run-telemetry/`
+
+### ISS-014 — Add model/task fitness check
+- **Milestone:** M6
+- **Source:** filed 2026-08-05 from `docs/ROADMAP_PLAN.md` M6 scope
+- **Fix:** landed on branch `add-model-task-fitness-check`. New `py_mono/skill/fitness.py`:
+  `check_model_fitness(skill, provider, model)` reads `ISS-013`'s telemetry log, and — only once
+  at least 3 recorded runs exist for the exact (skill, provider, model) combination — warns if
+  at least half of the most recent 5 matching runs failed. Hooked into `run_skill_safe`
+  (`py_mono/skill/approval.py`): a warning (if any) is prepended to a successful result; a
+  failed run attaches no warning (its own exception is already the signal). Directly
+  productizes the `ISS-009`/`ISS-011` lesson (thinking models reasoning verbosely/unreliably on
+  template-filling tasks) as an evidence-based check, not a hardcoded list of "bad" models.
+  Added `tests/test_skill_fitness.py` (6 tests) and 3 new tests in
+  `tests/test_skill_approval.py`. See `specs/012-add-model-task-fitness-check/`

--- a/docs/ROADMAP_PLAN.md
+++ b/docs/ROADMAP_PLAN.md
@@ -77,11 +77,19 @@ modes every session.
    Originally scoped as an M7 shared dependency, pulled forward into M6 since `ISS-014` needs it
    and M6 ships first; M7 extends this same log rather than building a second one. See
    [[ISSUES]] and `specs/011-add-skill-run-telemetry/`.
-7. **`ISS-014`** — model/task fitness check: warn before a heavy generation call if the
-   configured model looks like a poor fit for structured output. The clearest "bug we hit →
-   feature that prevents the next one" line of anything discussed this session — directly
-   productizes the `ISS-009`/`ISS-011` lesson (thinking models reasoning verbosely/unreliably on
-   template-filling tasks). Depends on `ISS-013` — sequence last within M6.
+7. **`ISS-014`** — **done.** `py_mono/skill/fitness.py`'s `check_model_fitness` warns when a
+   (skill, provider, model) combination has recently failed at least half its runs (min. 3
+   samples, most recent 5 considered), prepended to the result via `run_skill_safe`. The
+   clearest "bug we hit → feature that prevents the next one" line of anything discussed this
+   session — directly productizes the `ISS-009`/`ISS-011` lesson. See [[ISSUES]] and
+   `specs/012-add-model-task-fitness-check/`.
+
+**Note on this branch's view:** every M6 scope item above has a merged-or-open fix from this
+session (`ISS-005` #96, `ISS-006` #97, `ISS-010` #98, `ISS-011` #99, `ISS-012` #100, `ISS-013`
+#101, `ISS-014` — this branch). This branch only has `ISS-013` merged in alongside its own work,
+so its own copy of the Open/Tracked Index above still lists the others as open until each PR
+actually merges — update the Status line and Milestone Index once all seven have landed on
+`main`, rather than trusting this note in isolation.
 
 ---
 

--- a/py_mono/skill/approval.py
+++ b/py_mono/skill/approval.py
@@ -6,6 +6,7 @@ from typing import Optional, Dict
 
 from py_mono.skill.base import SkillRegistry, SkillContext, Skill
 from py_mono.skill.telemetry import log_skill_run
+from py_mono.skill.fitness import check_model_fitness
 
 
 class ApprovalError(Exception):
@@ -151,11 +152,15 @@ def run_skill_safe(
         except Exception:
             pass
 
+    fitness_warning = check_model_fitness(skill_name, provider_name, model_name)
+
     start = time.monotonic()
     success = False
     try:
         result = skill.run(request, safe_context)
         success = True
+        if fitness_warning:
+            return f"{fitness_warning}\n\n{result}"
         return result
     except Exception as e:
         raise RuntimeError(

--- a/py_mono/skill/fitness.py
+++ b/py_mono/skill/fitness.py
@@ -1,0 +1,61 @@
+# py_mono/skill/fitness.py
+"""
+Model/task fitness check (ISS-014).
+
+Warns before returning a skill's result if telemetry (ISS-013) shows this
+exact (skill, provider, model) combination has recently failed more often
+than not. Productizes the ISS-009/ISS-011 lesson (thinking models reasoning
+verbosely/unreliably on structured, template-filling tasks) as a general,
+evidence-based check — driven by this repo's own recorded history, not a
+hardcoded list of "bad" models.
+
+Non-blocking by design: this only ever adds a warning banner to a skill's
+result, never prevents execution. Requires at least MIN_SAMPLES prior
+recorded runs for the exact combination before making any judgment, so a
+single failure never triggers a false-positive warning.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+from py_mono.skill.telemetry import TELEMETRY_LOG, read_skill_runs
+
+MIN_SAMPLES = 3
+RECENT_WINDOW = 5
+FAILURE_RATE_THRESHOLD = 0.5
+
+
+def check_model_fitness(
+    skill: str,
+    provider: str,
+    model: str,
+    log_path: Path = TELEMETRY_LOG,
+) -> Optional[str]:
+    """Return a warning string if this (skill, provider, model) combination
+    has failed at least FAILURE_RATE_THRESHOLD of its most recent
+    RECENT_WINDOW runs, else None.
+    """
+    records = read_skill_runs(log_path)
+    matching = [
+        r
+        for r in records
+        if r.get("skill") == skill
+        and r.get("provider") == provider
+        and r.get("model") == model
+    ]
+
+    if len(matching) < MIN_SAMPLES:
+        return None
+
+    recent = matching[-RECENT_WINDOW:]
+    failures = sum(1 for r in recent if not r.get("success"))
+    failure_rate = failures / len(recent)
+
+    if failure_rate < FAILURE_RATE_THRESHOLD:
+        return None
+
+    return (
+        f"⚠️ Fitness warning: skill '{skill}' has failed {failures}/{len(recent)} recent "
+        f"runs with provider={provider} model={model}. This model may be a poor fit for "
+        f"this task — consider switching providers/models (`/provider <name> [model]`)."
+    )

--- a/specs/012-add-model-task-fitness-check/plan.md
+++ b/specs/012-add-model-task-fitness-check/plan.md
@@ -1,0 +1,67 @@
+# Implementation Plan: Model/task fitness check
+
+**Branch**: `add-model-task-fitness-check` | **Date**: 2026-08-05 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/012-add-model-task-fitness-check/spec.md`
+
+## Summary
+
+New module `py_mono/skill/fitness.py`: `check_model_fitness(skill, provider, model,
+log_path=TELEMETRY_LOG)` reads telemetry via `read_skill_runs` (`ISS-013`), filters to records
+matching the exact (skill, provider, model) triple, and — only once at least `MIN_SAMPLES` (3)
+matching records exist — checks whether the failure rate over the most recent `RECENT_WINDOW`
+(5) matching records is at or above `FAILURE_RATE_THRESHOLD` (0.5). Returns a warning string if
+so, else `None`. Hooked into `run_skill_safe` (`py_mono/skill/approval.py`) right before timing
+the skill's execution: on a successful run, if a warning was returned, it's prepended to the
+result string; on a failed run, no warning is attached (there's no successful result to prepend
+to, and the run's own `RuntimeError` is already the signal).
+
+## Technical Context
+
+**Language/Version**: Python (unchanged)
+
+**Primary Dependencies**: None new — reuses `py_mono.skill.telemetry.read_skill_runs`
+(`ISS-013`) directly
+
+**Storage**: Reads the existing `telemetry/skill_runs.jsonl` (`ISS-013`); writes nothing new
+
+**Testing**: `pytest`; new `tests/test_skill_fitness.py` (6 tests) for the check itself, plus 3
+new tests added to `tests/test_skill_approval.py` covering the `run_skill_safe` integration
+(warning prepended on success, no warning when none returned, no warning on a failed run)
+
+**Target Platform**: Unchanged
+
+**Project Type**: Single project — one new module, one existing function extended
+
+**Constraints**: Fitness logic lives entirely in its own module; `run_skill_safe` gains one
+warning-check call and one conditional string prefix, no other behavior changed
+
+**Scale/Scope**: Small — one new ~50-line module, ~5 lines added to `run_skill_safe`, two test
+files (one new, one extended)
+
+## Constitution Check
+
+- **Principle I (Minimal, Targeted Changes)**: PASS — fitness logic is fully isolated in its own
+  module; `run_skill_safe`'s change is a single warning-check call plus a conditional prefix on
+  the already-existing return statement.
+- **Principle IV (Test Coverage for New Behavior)**: PASS — 9 new tests total (6 for the module
+  covering sample-size/threshold/window/cross-contamination edge cases, 3 for the
+  `run_skill_safe` integration).
+- **Principle V (Incremental Change Philosophy)**: PASS — a skill's result is unchanged unless a
+  warning genuinely applies; no existing interface or return type changed (still a plain string).
+
+No violations.
+
+## Project Structure
+
+### Source Code (repository root)
+
+```text
+py_mono/skill/fitness.py           # new: check_model_fitness
+py_mono/skill/approval.py          # run_skill_safe: fitness-check hook added
+tests/test_skill_fitness.py        # new: 6 tests
+tests/test_skill_approval.py       # extended: 3 new tests
+```
+
+**Structure Decision**: No new structure — one new module alongside the existing
+`py_mono/skill/telemetry.py` and `py_mono/skill/approval.py`, one existing function extended.

--- a/specs/012-add-model-task-fitness-check/spec.md
+++ b/specs/012-add-model-task-fitness-check/spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: Model/task fitness check
+
+**Feature Branch**: `add-model-task-fitness-check`
+
+**Created**: 2026-08-05
+
+**Status**: Draft (documents completed, verified work)
+
+**Input**: User description: "Add ISS-014 — warn before a heavy generation call if the
+configured model looks like a poor fit for structured output, using the ISS-013 telemetry log
+as the data source. Productizes the ISS-009/ISS-011 lesson (thinking models reasoning
+verbosely/unreliably on template-filling tasks). Depends on ISS-013 landing first. See
+docs/ROADMAP_PLAN.md Milestone 6 and docs/ISSUES.md ISS-014."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Get warned when a model/task combination has a real failure history (Priority: P1)
+
+An operator runs a skill using a provider/model combination that has recently failed more often
+than not for that exact skill. Instead of discovering this the hard way each time, the result
+carries a visible warning suggesting they switch providers/models.
+
+**Why this priority**: This is the concrete, evidence-based feature named in Milestone 6 —
+"the clearest bug-we-hit-to-feature-that-prevents-the-next-one line" from this session, directly
+motivated by two real bugs (`ISS-009`, `ISS-011`) both involving a poor-fit model.
+
+**Independent Test**: Seed the telemetry log with a majority-failing history for a (skill,
+provider, model) combination, run that skill again, and confirm the result carries a warning.
+
+**Acceptance Scenarios**:
+
+1. **Given** a (skill, provider, model) combination has failed at least half of its most recent
+   runs (with at least a minimum sample size recorded), **When** that skill runs again, **Then**
+   the result is prefixed with a warning naming the skill, provider, model, and observed failure
+   count.
+2. **Given** a (skill, provider, model) combination has a healthy success rate, **When** that
+   skill runs, **Then** no warning is added and the result is unchanged.
+3. **Given** a (skill, provider, model) combination has fewer recorded runs than the minimum
+   sample size, **When** that skill runs, **Then** no warning is added (avoids a false positive
+   from a single failure).
+4. **Given** a skill run itself fails, **When** the exception propagates, **Then** no fitness
+   warning is attached (there is no successful result to attach it to).
+
+### Edge Cases
+
+- Does an old run of failures permanently flag a model even after a fix lands? No — only the
+  most recent window of runs for that exact combination is considered, so the flag clears once
+  enough recent runs succeed.
+- Does a failure for a *different* skill, provider, or model pollute this check? No — matching
+  is exact on all three fields; telemetry for unrelated combinations is ignored.
+- What if the telemetry log doesn't exist yet (fresh install)? No warning — the check requires
+  actual recorded history and degrades to "no opinion" when none exists, never erroring.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST warn when a (skill, provider, model) combination's most recent
+  runs show a failure rate at or above a defined threshold.
+- **FR-002**: The system MUST NOT warn when there are fewer recorded runs for that exact
+  combination than a defined minimum sample size.
+- **FR-003**: The check MUST use only telemetry for the exact (skill, provider, model)
+  combination being run — no cross-contamination from other skills, providers, or models.
+- **FR-004**: The check MUST consider only a recent window of runs, not full history, so
+  fitness improves once a fixed model/provider starts succeeding again.
+- **FR-005**: A warning MUST be non-blocking — it never prevents the skill from running, only
+  adds visibility to the result.
+- **FR-006**: A warning MUST NOT be attached to a failed run (there is no successful result to
+  prepend it to; the run's own exception is already the signal in that case).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A combination with a majority-failing recent history produces a visible warning
+  on its next run, verified by an automated test.
+- **SC-002**: A combination with a healthy history, or with too little history, produces no
+  warning, verified by automated tests for both cases.
+- **SC-003**: The check requires no new configuration or hardcoded model list — it is derived
+  entirely from telemetry already being recorded (`ISS-013`).
+
+## Assumptions
+
+- A minimum sample size of 3 and a failure-rate threshold of 50% over the most recent 5 runs is
+  a reasonable, conservative starting point — tunable later once real usage data accumulates,
+  but chosen now specifically to avoid false positives from a single bad run (the exact false
+  positive this project's own `ISS-009` incident could otherwise have caused if a fitness check
+  had existed and reacted to one failure).
+- The warning is surfaced as a plain text prefix on the skill's returned string, consistent with
+  this codebase's existing convention of emoji-prefixed status messages (✅/❌ elsewhere) rather
+  than a new structured warning channel.

--- a/specs/012-add-model-task-fitness-check/tasks.md
+++ b/specs/012-add-model-task-fitness-check/tasks.md
@@ -1,0 +1,43 @@
+# Tasks: Model/task fitness check
+
+**Input**: Design documents from `/specs/012-add-model-task-fitness-check/`
+
+All tasks below were already executed and verified.
+
+## Phase 1: Setup
+
+- [x] T001 Confirm `py_mono/skill/telemetry.py`'s `read_skill_runs` (`ISS-013`, merged into
+      this branch) is available as the data source
+
+## Phase 2: User Story 1 - Get warned on a real failure history (Priority: P1)
+
+- [x] T002 [US1] Create `py_mono/skill/fitness.py`: `check_model_fitness(skill, provider,
+      model, log_path=TELEMETRY_LOG)` filters `read_skill_runs()` output to the exact matching
+      triple, requires `MIN_SAMPLES = 3` before judging, considers only the most recent
+      `RECENT_WINDOW = 5` matching records, and returns a warning string when the failure rate
+      is `>= FAILURE_RATE_THRESHOLD (0.5)`, else `None`
+- [x] T003 [US1] Instrument `run_skill_safe` in `py_mono/skill/approval.py`: call
+      `check_model_fitness(skill_name, provider_name, model_name)` before timing execution;
+      on success, prepend the warning (if any) to the returned result; on failure, no warning is
+      attached
+- [x] T004 [US1] [P] Add `tests/test_skill_fitness.py` (6 tests): no warning below minimum
+      sample size, no warning below the failure-rate threshold, warning at/above the threshold
+      (with correct counts in the message), other skill/provider/model combinations don't
+      contaminate the result, only the recent window is considered (old failures outside the
+      window don't count), missing telemetry file returns `None`
+- [x] T005 [US1] [P] Add 3 tests to `tests/test_skill_approval.py`: a returned warning is
+      prepended to a successful result, no prefix appears when no warning is returned, a failed
+      run still raises with no warning attached
+- [x] T006 [US1] Run `pytest tests/test_skill_fitness.py tests/test_skill_approval.py -v`:
+      16 passed
+
+## Phase 3: Polish & Cross-Cutting
+
+- [x] T007 Run full suite + `compileall`: no new regressions (5 pre-existing, unrelated
+      `ISS-005`-class failures present on a fresh `main` branch, tracked/fixed separately in
+      PR #96); all 9 new tests included in the pass count
+
+## Dependencies & Execution Order
+
+Depends on `ISS-013` (`py_mono/skill/telemetry.py`, merged into this branch) already existing —
+this feature has no data source without it, per Milestone 6's documented ordering.

--- a/tests/test_skill_approval.py
+++ b/tests/test_skill_approval.py
@@ -211,3 +211,61 @@ def test_run_with_no_session_manager_does_not_crash(monkeypatch):
     run_skill_safe(registry, "allowed_only", "/skill allowed_only", context)
 
     assert logged == [("<unknown>", "<unknown>")]
+
+
+# ---------------------------------------------------------------------------
+# ISS-014: run_skill_safe prepends a fitness warning when one is returned
+# ---------------------------------------------------------------------------
+
+def test_fitness_warning_is_prepended_to_a_successful_result(monkeypatch):
+    skill = UsesAllowedToolSkill()
+    registry = StubRegistry(
+        skill,
+        {"allowed_only": {"status": "approved", "allowed_tools": ["list_files"]}},
+    )
+
+    monkeypatch.setattr("py_mono.skill.approval.log_skill_run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "py_mono.skill.approval.check_model_fitness",
+        lambda skill, provider, model: "⚠️ Fitness warning: test warning",
+    )
+
+    result = run_skill_safe(registry, "allowed_only", "/skill allowed_only", make_context())
+
+    assert result.startswith("⚠️ Fitness warning: test warning")
+    assert result.endswith("ok")  # the skill's real result is still present
+
+
+def test_no_fitness_warning_prefix_when_none_returned(monkeypatch):
+    skill = UsesAllowedToolSkill()
+    registry = StubRegistry(
+        skill,
+        {"allowed_only": {"status": "approved", "allowed_tools": ["list_files"]}},
+    )
+
+    monkeypatch.setattr("py_mono.skill.approval.log_skill_run", lambda *a, **k: None)
+    monkeypatch.setattr("py_mono.skill.approval.check_model_fitness", lambda skill, provider, model: None)
+
+    result = run_skill_safe(registry, "allowed_only", "/skill allowed_only", make_context())
+
+    assert result == "ok"
+
+
+def test_fitness_warning_is_not_shown_on_a_failed_run(monkeypatch):
+    """A fitness warning is only useful attached to a result the caller
+    actually receives - a failed run raises instead, so there's no result to
+    prepend it to."""
+    skill = FailingSkill()
+    registry = StubRegistry(
+        skill,
+        {"failing_skill": {"status": "approved", "allowed_tools": ["list_files"]}},
+    )
+
+    monkeypatch.setattr("py_mono.skill.approval.log_skill_run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "py_mono.skill.approval.check_model_fitness",
+        lambda skill, provider, model: "⚠️ Fitness warning: test warning",
+    )
+
+    with pytest.raises(RuntimeError, match="execution failed"):
+        run_skill_safe(registry, "failing_skill", "/skill failing_skill", make_context())

--- a/tests/test_skill_fitness.py
+++ b/tests/test_skill_fitness.py
@@ -1,0 +1,71 @@
+"""Tests for py_mono/skill/fitness.py (ISS-014): a model/task fitness check
+driven by the telemetry log (ISS-013), not a hardcoded list of "bad"
+models."""
+
+from py_mono.skill.fitness import check_model_fitness
+from py_mono.skill.telemetry import log_skill_run
+
+
+def _log(log_path, skill="generate_skill", provider="OllamaProvider", model="qwen3.5:4b", success=True):
+    log_skill_run(skill, provider, model, 100.0, success, log_path=log_path)
+
+
+def test_no_warning_with_fewer_than_min_samples(tmp_path):
+    log_path = tmp_path / "skill_runs.jsonl"
+    _log(log_path, success=False)
+    _log(log_path, success=False)  # only 2 records, MIN_SAMPLES is 3
+
+    assert check_model_fitness("generate_skill", "OllamaProvider", "qwen3.5:4b", log_path=log_path) is None
+
+
+def test_no_warning_when_failure_rate_below_threshold(tmp_path):
+    log_path = tmp_path / "skill_runs.jsonl"
+    for success in (True, True, True, True, False):  # 1/5 = 20% failure
+        _log(log_path, success=success)
+
+    assert check_model_fitness("generate_skill", "OllamaProvider", "qwen3.5:4b", log_path=log_path) is None
+
+
+def test_warning_when_failure_rate_at_threshold(tmp_path):
+    log_path = tmp_path / "skill_runs.jsonl"
+    for success in (True, False, False):  # 2/3 = 67% failure
+        _log(log_path, success=success)
+
+    warning = check_model_fitness("generate_skill", "OllamaProvider", "qwen3.5:4b", log_path=log_path)
+    assert warning is not None
+    assert "generate_skill" in warning
+    assert "OllamaProvider" in warning
+    assert "qwen3.5:4b" in warning
+    assert "2/3" in warning
+
+
+def test_only_matching_skill_provider_model_combination_counts(tmp_path):
+    log_path = tmp_path / "skill_runs.jsonl"
+    # Plenty of failures, but for a different skill/provider/model - must not
+    # contaminate the combination actually being checked.
+    for _ in range(5):
+        _log(log_path, skill="other_skill", success=False)
+    for _ in range(5):
+        _log(log_path, provider="LiteLLMProvider", success=False)
+    for _ in range(5):
+        _log(log_path, model="qwen2.5-coder:7b-instruct-q5_K_M", success=False)
+
+    assert check_model_fitness("generate_skill", "OllamaProvider", "qwen3.5:4b", log_path=log_path) is None
+
+
+def test_only_recent_window_is_considered(tmp_path):
+    log_path = tmp_path / "skill_runs.jsonl"
+    # 5 old failures, then 5 recent successes - RECENT_WINDOW is 5, so only
+    # the recent successes should count.
+    for _ in range(5):
+        _log(log_path, success=False)
+    for _ in range(5):
+        _log(log_path, success=True)
+
+    assert check_model_fitness("generate_skill", "OllamaProvider", "qwen3.5:4b", log_path=log_path) is None
+
+
+def test_no_telemetry_file_returns_none(tmp_path):
+    assert check_model_fitness(
+        "generate_skill", "OllamaProvider", "qwen3.5:4b", log_path=tmp_path / "does_not_exist.jsonl"
+    ) is None


### PR DESCRIPTION
## Summary
- New `py_mono/skill/fitness.py`: `check_model_fitness(skill, provider, model)` reads `ISS-013`'s telemetry log and, once at least 3 recorded runs exist for the exact combination, warns if at least half of the most recent 5 matching runs failed. No opinion (returns `None`) below the minimum sample size — avoids a false-positive from a single bad run.
- Hooked into `run_skill_safe` (`py_mono/skill/approval.py`): a warning is prepended to a successful result; a failed run attaches no warning.
- Directly productizes the `ISS-009`/`ISS-011` lesson (thinking models reasoning verbosely/unreliably on structured tasks) as an evidence-based check, not a hardcoded model list.
- **Depends on `ISS-013` (#101)** — merged into this branch for validation, same pattern as #100/#96.
- **This is the last item in Milestone 6.** Closes `ISS-014` in `docs/ISSUES.md`; SDD trail in `specs/012-add-model-task-fitness-check/`.
- Note: since M6's seven items were built as independent parallel PRs (#96, #97, #98, #99, #100, #101, this one), each touches `docs/ISSUES.md`/`docs/ROADMAP_PLAN.md` — expect merge conflicts on those two files depending on merge order. Once all seven are on `main`, the Milestone 6 status line and Milestone Index in `docs/ROADMAP_PLAN.md` should get a final pass to say "done."

## Test plan
- [x] `pytest tests/test_skill_fitness.py tests/test_skill_approval.py -v` — 16 passed
- [x] Full suite — no new regressions (5 pre-existing `ISS-005` failures tracked/fixed separately in #96, unrelated to this change)
- [x] `python -m compileall -q py_mono skills` — clean